### PR TITLE
Fix if-let when-let and add put-in (assoc-in)

### DIFF
--- a/examples/utils.dst
+++ b/examples/utils.dst
@@ -1,0 +1,22 @@
+
+(defn put-in [coll keys val]
+  (defn assoc [the-coll n]
+    (if-let [current-key (get keys n)
+             current-val (get the-coll current-key)]
+          (put the-coll current-key (assoc current-val (inc n)))
+      val))
+  (assoc coll 0))
+
+
+(defn update-in [coll keys an-fn]
+  (def new-keys (array-slice  coll 0 -2) )
+  (def last-key (get (array-slice  coll -1 -2) 0))
+  (defn assoc [the-coll n]
+    (if-let [current-key (get keys n)
+             current-val (get the-coll current-key)]
+      (put the-coll current-key (assoc current-val (inc n)))
+      ( update  the-coll last-key an-fn )))
+  (assoc coll  new-keys   0))
+
+
+;; (defn update-in-test [ ] (update-in @{:a "x" :b {:y {"pipa" 3}}} [:b :y "pipa"] type))

--- a/src/compiler/boot.dst
+++ b/src/compiler/boot.dst
@@ -367,13 +367,16 @@ If no match is found, returns nil"
   (tuple 'when (tuple not condition) exp-1))
 
 (defmacro if-let
-"Takes the first one or two forms in a vector and if true binds
+"Takes the first one or two forms in a vector and if both are  true binds
  all the forms with let and evaluates the first expression else
  evaluates the second"
   [bindings then else]
-  (def head (ast-unwrap1 bindings))
-  (tuple 'let head
-         (tuple 'if (and (get head 1) (if (get head 2) (get head 3) true))
+  #(tuple 'print   (tuple '> (tuple 'length bindings) 2))
+  (tuple 'let bindings
+         (tuple 'if (tuple 'and (tuple 'get bindings 1)
+                           (tuple 'if
+                                  (tuple '> (tuple 'length bindings) 2)
+                                  (tuple 'get bindings 3) 'true))
               then
               else)))
 
@@ -385,7 +388,10 @@ If no match is found, returns nil"
   (tuple 'let head
       (tuple
         'when
-        (and (get head 1) (if (get head 2) (get head 3) true))
+        (tuple 'and (tuple 'get bindings 1)
+                           (tuple 'if
+                                  (tuple '> (tuple 'length bindings) 2)
+                                  (tuple 'get bindings 3) 'true))
         (apply1 tuple (array-concat ['do] (ast-unwrap1 body))))))
 
 (defn comp

--- a/src/compiler/boot.dst
+++ b/src/compiler/boot.dst
@@ -371,7 +371,6 @@ If no match is found, returns nil"
  all the forms with let and evaluates the first expression else
  evaluates the second"
   [bindings then else]
-  #(tuple 'print   (tuple '> (tuple 'length bindings) 2))
   (tuple 'let bindings
          (tuple 'if (tuple 'and (tuple 'get bindings 1)
                            (tuple 'if
@@ -384,8 +383,7 @@ If no match is found, returns nil"
 "Takes the first one or two forms in vector and if true binds
  all the forms  with let and evaluates the body"
   [bindings & body]
-  (def head (ast-unwrap1 bindings))
-  (tuple 'let head
+  (tuple 'let bindings
       (tuple
         'when
         (tuple 'and (tuple 'get bindings 1)


### PR DESCRIPTION
There seems to be some problem with ast-unwrap(1) and recursion. It seems that subsequent calls and changes the argument of ast-unarwap doesn't work but i have not a clear mind right now. I might test it later.
I added a put-in (it took me more that expected to implement it due to if-let). 
Before you push your implementations of array literals, maybe we could use [] to  avoid (tuple ...) when writing macros? I think it would be very convenient.
